### PR TITLE
command-line interface

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,11 +5,27 @@ blocks. It is a rewrite of https://gist.github.com/mattharrison/2a1a263597d80e99
 
 Usage
 -----
-There is no commandline interface, yet. Until it is added, use:
+The commandline interface supports two modes: checking and inplace
+reformatting.
 
 .. code:: bash
 
-    # preview
-    python -c 'import blackdoc; import pathlib; path = pathlib.Path("file.py"); print(blackdoc.format_file(path))'
-    # inplace conversion
-    python -c 'import blackdoc; import pathlib; path = pathlib.Path("file.py"); path.write_text(blackdoc.format_file(path))'
+    python -m blackdoc --help
+
+
+In inplace reformatting mode, it will reformat the doctest lines and
+write them back to disk:
+
+.. code:: bash
+
+    # on explicitly mentioned files
+    python -m blackdoc file1.py file2.py
+    # on the whole directory
+    python -m blackdoc file1.py file2.py
+
+
+When checking, it will report the changed files but will not write them to disk:
+
+.. code:: bash
+
+    python -m blackdoc --check .

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ write them back to disk:
     # on explicitly mentioned files
     python -m blackdoc file1.py file2.py
     # on the whole directory
-    python -m blackdoc file1.py file2.py
+    python -m blackdoc .
 
 
 When checking, it will report the changed files but will not write them to disk:

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -252,6 +252,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-l",
         "--line-length",
+        metavar="INT",
         type=int,
         default=black.DEFAULT_LINE_LENGTH,
         help="How many characters per line to allow.",
@@ -267,6 +268,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--include",
+        metavar="TEXT",
         type=str,
         default=black.DEFAULT_INCLUDES,
         help=(
@@ -279,6 +281,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--exclude",
+        metavar="TEXT",
         type=str,
         default=black.DEFAULT_EXCLUDES,
         help=(

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -233,7 +233,8 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "-t",
-        action="store",
+        "--target-versions",
+        action="append",
         choices=[v.name.lower() for v in black.TargetVersion],
         help=(
             "Python versions that should be supported by Black's output. (default: "

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -218,7 +218,27 @@ def collect_files(src, include, exclude):
 
 
 def format_and_overwrite(path, mode):
-    pass
+    with open(path, mode="rb") as f:
+        content, encoding, newline = black.decode_bytes(f.read())
+
+    lines = content.split("\n")
+
+    try:
+        new_content = "\n".join(format_lines(lines, mode))
+
+        if new_content == content:
+            result = "unchanged"
+        else:
+            print(f"reformatted {path}")
+            result = "reformatted"
+    except Exception as e:
+        print(f"error: cannot format {path.absolute()}: {e}")
+        result = "error"
+
+    with open(path, "w", encoding=encoding, newline=newline) as f:
+        f.write(new_content)
+
+    return result
 
 
 def format_and_check(path, mode):

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -259,6 +259,29 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
+        "--include",
+        type=str,
+        default=black.DEFAULT_INCLUDES,
+        help=(
+            "A regular expression that matches files and directories that should be "
+            "included on recursive searches.  An empty value means all files are "
+            "included regardless of the name.  Use forward slashes for directories on "
+            "all platforms (Windows, too).  Exclusions are calculated first, inclusions "
+            "later."
+        ),
+    )
+    parser.add_argument(
+        "--exclude",
+        type=str,
+        default=black.DEFAULT_EXCLUDES,
+        help=(
+            "A regular expression that matches files and directories that should be "
+            "excluded on recursive searches.  An empty value means no paths are excluded. "
+            "Use forward slashes for directories on all platforms (Windows, too).  "
+            "Exclusions are calculated first, inclusions later."
+        ),
+    )
+    parser.add_argument(
         "src", action="store", type=pathlib.Path, nargs="?", default=None,
     )
 

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -218,12 +218,12 @@ def collect_files(src, include, exclude):
 
 
 def format_and_overwrite(path, mode):
-    with open(path, mode="rb") as f:
-        content, encoding, newline = black.decode_bytes(f.read())
-
-    lines = content.split("\n")
-
     try:
+        with open(path, mode="rb") as f:
+            content, encoding, newline = black.decode_bytes(f.read())
+
+        lines = content.split("\n")
+
         new_content = "\n".join(format_lines(lines, mode))
 
         if new_content == content:
@@ -231,23 +231,23 @@ def format_and_overwrite(path, mode):
         else:
             print(f"reformatted {path}")
             result = "reformatted"
+
+        with open(path, "w", encoding=encoding, newline=newline) as f:
+            f.write(new_content)
     except Exception as e:
         print(f"error: cannot format {path.absolute()}: {e}")
         result = "error"
-
-    with open(path, "w", encoding=encoding, newline=newline) as f:
-        f.write(new_content)
 
     return result
 
 
 def format_and_check(path, mode):
-    with open(path, mode="rb") as f:
-        content, _, _ = black.decode_bytes(f.read())
-
-    lines = content.split("\n")
-
     try:
+        with open(path, mode="rb") as f:
+            content, _, _ = black.decode_bytes(f.read())
+
+        lines = content.split("\n")
+
         new_content = "\n".join(format_lines(lines, mode))
 
         if new_content == content:

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -245,7 +245,13 @@ def process(args):
         print("No Python files are present to be formatted. Nothing to do 😴")
         return 0
 
-    print(sources)
+    target_versions = set(getattr(args, "target_versions", ()))
+    mode = black.FileMode(
+        line_length=args.line_length, target_versions=target_versions,
+    )
+
+    write_back = not args.check
+    print(sources, mode, write_back)
 
 
 if __name__ == "__main__":

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -188,7 +188,7 @@ def unclassify(labelled_lines):
 def format_lines(lines, mode=None):
     labeled = classify(lines)
     grouped = group_code_units(labeled)
-    blackened = blacken(grouped)
+    blackened = blacken(grouped, mode=mode)
 
     return unclassify(blackened)
 

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -339,7 +339,10 @@ def process(args):
         print("No Python files are present to be formatted. Nothing to do 😴")
         return 0
 
-    target_versions = set(getattr(args, "target_versions", ()))
+    target_versions = set(
+        black.TargetVersion[version.upper()]
+        for version in getattr(args, "target_versions", ())
+    )
     mode = black.FileMode(
         line_length=args.line_length, target_versions=target_versions,
     )

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -1,4 +1,6 @@
 import copy
+import pathlib
+import sys
 import textwrap
 
 import black
@@ -193,5 +195,71 @@ def format_text(text):
     return "\n".join(format_lines(text.split("\n")))
 
 
+def collect_files(path):
+    pass
+
+
+def process(args):
+    if args.src is None:
+        print("No Path provided. Nothing to do 😴")
+        return 0
+
+    if args.src.is_dir():
+        paths = [
+            path
+            for path in collect_files(
+                args.src, include=args.include, exclude=args.exclude
+            )
+        ]
+    elif args.src.is_file():
+        paths = [args.src]
+    elif not args.src.exists():
+        print(
+            f'Error: Invalid value for "[SRC]...": Path "{args.src}" does not exist.',
+            file=sys.stderr,
+        )
+        return 2
+
+    mode = black.FileMode(line_length=args.line_length)
+    mode, paths
+
+
 if __name__ == "__main__":
-    print("command line interface not available yet")
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="run black on documentation code snippets (e.g. doctest)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "-t",
+        action="store",
+        choices=[v.name.lower() for v in black.TargetVersion],
+        help=(
+            "Python versions that should be supported by Black's output. (default: "
+            "per-file auto-detection)"
+        ),
+        default=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "-l",
+        "--line-length",
+        type=int,
+        default=black.DEFAULT_LINE_LENGTH,
+        help="How many characters per line to allow.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help=(
+            "Don't write the files back, just return the status.  Return code 0 "
+            "means nothing would change.  Return code 1 means some files would be "
+            "reformatted.  Return code 123 means there was an internal error."
+        ),
+    )
+    parser.add_argument(
+        "src", action="store", type=pathlib.Path, nargs="?", default=None,
+    )
+
+    args = parser.parse_args()
+    sys.exit(process(args))

--- a/blackdoc.py
+++ b/blackdoc.py
@@ -207,28 +207,12 @@ def collect_files(path):
 
 
 def process(args):
-    if args.src is None:
+    if not args.src:
         print("No Path provided. Nothing to do 😴")
         return 0
 
-    if args.src.is_dir():
-        paths = [
-            path
-            for path in collect_files(
-                args.src, include=args.include, exclude=args.exclude
-            )
-        ]
-    elif args.src.is_file():
-        paths = [args.src]
-    elif not args.src.exists():
-        print(
-            f'Error: Invalid value for "[SRC]...": Path "{args.src}" does not exist.',
-            file=sys.stderr,
-        )
-        return 2
-
     mode = black.FileMode(line_length=args.line_length)
-    mode, paths
+    mode
 
 
 if __name__ == "__main__":
@@ -292,7 +276,12 @@ if __name__ == "__main__":
         ),
     )
     parser.add_argument(
-        "src", action="store", type=pathlib.Path, nargs="?", default=None,
+        "src",
+        action="store",
+        type=pathlib.Path,
+        nargs="*",
+        default=None,
+        help="one or more paths to work on",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
A tool is almost always used via its command-line interface so to be useful we need one, too. The one introduced here mostly mimics / copies the interface of `black`.

It implements two different modes:
- [x] checking for necessary changes
- [x] reformatting inplace
