### PR TITLE
Version option

### DIFF
--- a/blackdoc/__init__.py
+++ b/blackdoc/__init__.py
@@ -1,6 +1,15 @@
+from importlib.metadata import version
+
 from .blacken import blacken
 from .classification import detect_format
 from .formats import register_format  # noqa
+
+try:
+    __version__ = version("black-doctest")
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "999"
 
 
 def line_numbers(lines):

--- a/blackdoc/__init__.py
+++ b/blackdoc/__init__.py
@@ -1,4 +1,7 @@
-from importlib.metadata import version
+try:
+    from importlib.metadata import version
+except ImportError:
+    from importlib_metadata import version
 
 from .blacken import blacken
 from .classification import detect_format

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -4,7 +4,7 @@ import sys
 
 import black
 
-from . import format_lines
+from . import __version__, format_lines
 
 
 def collect_files(src, include, exclude):
@@ -179,6 +179,8 @@ def process(args):
     return return_code
 
 
+program = pathlib.Path(__file__).parent.name
+
 parser = argparse.ArgumentParser(
     description="run black on documentation code snippets (e.g. doctest)",
     formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -238,6 +240,12 @@ parser.add_argument(
         "Use forward slashes for directories on all platforms (Windows, too).  "
         "Exclusions are calculated first, inclusions later."
     ),
+)
+parser.add_argument(
+    "--version",
+    action="version",
+    help="Show the version and exit.",
+    version=f"{program} {__version__}",
 )
 parser.add_argument(
     "src",

--- a/blackdoc/tests/test_init.py
+++ b/blackdoc/tests/test_init.py
@@ -1,0 +1,5 @@
+import blackdoc
+
+
+def test_version():
+    assert getattr(blackdoc, "__version__", "") not in ("", "999")

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,10 @@ long_description = file: README.rst
 url = https://github.com/keewis/black-doctest
 
 [options]
-install_requires = black; more_itertools
+install_requires =
+    black
+    more_itertools
+    importlib-metadata; python_version < 3.8
 setup_requires = setuptools; setuptools_scm
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ url = https://github.com/keewis/black-doctest
 install_requires =
     black
     more_itertools
-    importlib-metadata; python_version < 3.8
+    importlib-metadata; python_version < "3.8"
 setup_requires = setuptools; setuptools_scm
 
 [flake8]


### PR DESCRIPTION
Every library should have a `__version__` attribute and every program should have a `--version` option. This adds both, using `importlib.metadata` (falling back to `importlib-metadata` on `python<3.8`) and `setuptools_scm`.