### PR TITLE
badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,9 @@ black-doctest
 =============
 
 .. image:: https://github.com/keewis/black-doctest/workflows/CI/badge.svg?branch=master
-  :target: https://github.com/keewis/black-doctest/actions
+    :target: https://github.com/keewis/black-doctest/actions
+.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
+    :target: https://github.com/python/black
 
 `black-doctest` is a tool that applies `black` to code in doctest
 blocks. It is a rewrite of https://gist.github.com/mattharrison/2a1a263597d80e99cf85e898b800ec32

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,7 @@ black-doctest
 =============
 
 .. image:: https://github.com/keewis/black-doctest/workflows/CI/badge.svg?branch=master
+  :target: https://github.com/keewis/black-doctest/actions
 
 `black-doctest` is a tool that applies `black` to code in doctest
 blocks. It is a rewrite of https://gist.github.com/mattharrison/2a1a263597d80e99cf85e898b800ec32

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,8 @@
 black-doctest
 =============
+
+.. image:: https://github.com/keewis/black-doctest/workflows/CI/badge.svg?branch=master
+
 `black-doctest` is a tool that applies `black` to code in doctest
 blocks. It is a rewrite of https://gist.github.com/mattharrison/2a1a263597d80e99cf85e898b800ec32
 


### PR DESCRIPTION
The link of the CI badge points to all actions instead of just the CI on master because I couldn't figure out how to do that.

Todo (once we have that):
- badge for PyPI
- badge for docs